### PR TITLE
Update Linux dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,10 @@ jobs:
         os: [windows-2022, macos-13, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install Linux depencencies
+        if: runner.os == 'linux'
+        run: sudo apt update && sudo apt install -y libpulse-dev libsndio-dev pipewire libasound2-dev libsdl2-dev libjack-dev
+
       - uses: secondlife/action-autobuild@v3
         with:
           addrsize: "64" 


### PR DESCRIPTION
openal will not enable all audio backends without finding the required headers.

This should enable the most popular ones

@nat-goodspeed  or @bennettgoble  or whom it might concern :)