### PR TITLE
Drop depencency on SDL2-dev and libsndio

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Install Linux depencencies
         if: runner.os == 'linux'
-        run: sudo apt update && sudo apt install -y libpulse-dev libsndio-dev pipewire libasound2-dev libsdl2-dev libjack-dev
+        run: sudo apt update && sudo apt install -y libpulse-dev pipewire libasound2-dev libjack-dev
 
       - uses: secondlife/action-autobuild@v3
         with:


### PR DESCRIPTION
- libsndio is a more stranger audio system we can ignore for the moment.
- SDL2 is something the viewer does not uses and initialize for sound, so it should be okay to drop that one as well.