### PR TITLE
Build script housekeeping including proper use of build variables

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,11 +11,24 @@ jobs:
     strategy:
       matrix:
         os: [windows-2022, macos-13, ubuntu-22.04]
+        addrsize: ["64"]
+    continue-on-error: false
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Setup Homebrew Packages
+        if: ${{ runner.os == 'macOS' }}
+        shell: bash
+        run: brew install ninja
       - name: Install Linux depencencies
         if: runner.os == 'linux'
-        run: sudo apt update && sudo apt install -y libpulse-dev pipewire libasound2-dev libjack-dev
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt update
+          sudo apt install -y \
+            ninja-build libasound2-dev \
+            libpulse-dev libpipewire-0.3-dev \
+            libjack-dev libdbus-1-dev
 
       - uses: secondlife/action-autobuild@v4
         with:

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -63,7 +63,6 @@
           </map>
           <key>manifest</key>
           <array>
-            <string>lib/debug/*.dylib*</string>
             <string>lib/release/*.dylib*</string>
           </array>
           <key>name</key>
@@ -83,7 +82,6 @@
           </map>
           <key>manifest</key>
           <array>
-            <string>lib/debug/*.so*</string>
             <string>lib/release/*.so*</string>
           </array>
           <key>name</key>
@@ -103,8 +101,6 @@
           </map>
           <key>manifest</key>
           <array>
-            <string>lib/debug/OpenAL32.*</string>
-            <string>lib/debug/alut.*</string>
             <string>lib/release/OpenAL32.*</string>
             <string>lib/release/alut.*</string>
           </array>

--- a/build-cmd.sh
+++ b/build-cmd.sh
@@ -13,7 +13,7 @@ if [ -z "$AUTOBUILD" ] ; then
     exit 1
 fi
 
-if [ "$OSTYPE" = "cygwin" ] ; then
+if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]] ; then
     autobuild="$(cygpath -u $AUTOBUILD)"
 else
     autobuild="$AUTOBUILD"
@@ -26,6 +26,9 @@ stage="$(pwd)/stage"
 source_environment_tempfile="$stage/source_environment.sh"
 "$autobuild" source_environment > "$source_environment_tempfile"
 . "$source_environment_tempfile"
+
+# remove_cxxstd
+source "$(dirname "$AUTOBUILD_VARIABLES_FILE")/functions"
 
 # Restore all .sos
 restore_sos ()
@@ -53,40 +56,23 @@ pushd "$top/openal-soft"
         windows*)
             load_vsvars
 
-            if [ "$AUTOBUILD_ADDRSIZE" = 32 ]
-            then
-                archflags=""
-            else
-                archflags=""
-            fi
-
             # Create staging dirs
             mkdir -p "$stage/include/AL"
             mkdir -p "${stage}/lib/debug"
             mkdir -p "${stage}/lib/release"
 
-            # Debug Build
-            mkdir -p "build_debug"
-            pushd "build_debug"
-
-                cmake -E env CFLAGS="$archflags /Zi" CXXFLAGS="$archflags /Zi" LDFLAGS="/DEBUG:FULL" \
-                cmake .. -G "$AUTOBUILD_WIN_CMAKE_GEN" -A "$AUTOBUILD_WIN_VSPLATFORM" -DCMAKE_BUILD_TYPE="Debug" \
-                    -DALSOFT_UTILS=OFF -DALSOFT_NO_CONFIG_UTIL=ON -DALSOFT_EXAMPLES=OFF -DALSOFT_TESTS=OFF \
-                    -DCMAKE_INSTALL_PREFIX="$(cygpath -m "$stage")"
-
-                cmake --build . --config Debug --clean-first
-
-                cp -a Debug/OpenAL32.{lib,dll,exp,pdb} "$stage/lib/debug/"
-            popd
+            opts="$LL_BUILD_RELEASE"
+            plainopts="$(remove_cxxstd $opts)"
 
             # Release Build
-            mkdir -p "build_release"
-            pushd "build_release"
-
-                cmake -E env CFLAGS="$archflags /O2 /Ob3 /GL /Gy /Zi" CXXFLAGS="$archflags /O2 /Ob3 /GL /Gy /Zi /std:c++17 /permissive-" LDFLAGS="/LTCG /OPT:REF /OPT:ICF /DEBUG:FULL" \
-                cmake .. -G "$AUTOBUILD_WIN_CMAKE_GEN" -A "$AUTOBUILD_WIN_VSPLATFORM" -DCMAKE_BUILD_TYPE="Release" \
+            mkdir -p "build"
+            pushd "build"
+                cmake .. -G "Ninja Multi-Config" -DCMAKE_BUILD_TYPE="Release" \
                     -DALSOFT_UTILS=OFF -DALSOFT_NO_CONFIG_UTIL=ON -DALSOFT_EXAMPLES=OFF -DALSOFT_TESTS=OFF \
-                    -DCMAKE_INSTALL_PREFIX="$(cygpath -m "$stage")"
+                    -DCMAKE_INSTALL_PREFIX="$(cygpath -m "$stage")" \
+                    -DCMAKE_C_FLAGS="$plainopts" \
+                    -DCMAKE_CXX_FLAGS="$opts" \
+                    -DCMAKE_SHARED_LINKER_FLAGS="/DEBUG:FULL"
 
                 cmake --build . --config Release --clean-first
 
@@ -95,7 +81,7 @@ pushd "$top/openal-soft"
             cp include/AL/*.h $stage/include/AL/
 
             # Must be done after the build.  version.h is created as part of the build.
-            version="$(sed -n -E 's/#define ALSOFT_VERSION "([^"]+)"/\1/p' "build_release/version.h" | tr -d '\r' )"
+            version="$(sed -n -E 's/#define ALSOFT_VERSION "([^"]+)"/\1/p' "build/version.h" | tr -d '\r' )"
             echo "${version}" > "${stage}/VERSION.txt"
         ;;
 
@@ -105,12 +91,11 @@ pushd "$top/openal-soft"
             export SDKROOT=$(xcodebuild -version -sdk ${SDKNAME} Path)
 
             # Deploy Targets
-            X86_DEPLOY=10.15
-            ARM64_DEPLOY=11.0
+            export MACOSX_DEPLOYMENT_TARGET="$LL_BUILD_DARWIN_DEPLOY_TARGET"
 
             # Setup build flags
-            ARCH_FLAGS_X86="-arch x86_64 -mmacosx-version-min=${X86_DEPLOY} -isysroot ${SDKROOT} -msse4.2"
-            ARCH_FLAGS_ARM64="-arch arm64 -mmacosx-version-min=${ARM64_DEPLOY} -isysroot ${SDKROOT}"
+            ARCH_FLAGS_X86="-arch x86_64 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET} -isysroot ${SDKROOT} -msse4.2"
+            ARCH_FLAGS_ARM64="-arch arm64 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET} -isysroot ${SDKROOT}"
             DEBUG_COMMON_FLAGS="-O0 -g -fPIC -DPIC"
             RELEASE_COMMON_FLAGS="-O3 -g -fPIC -DPIC -fstack-protector-strong"
             DEBUG_CFLAGS="$DEBUG_COMMON_FLAGS"
@@ -121,9 +106,6 @@ pushd "$top/openal-soft"
             RELEASE_CPPFLAGS="-DPIC"
             DEBUG_LDFLAGS="-Wl,-headerpad_max_install_names"
             RELEASE_LDFLAGS="-Wl,-headerpad_max_install_names"
-
-            # x86 Deploy Target
-            export MACOSX_DEPLOYMENT_TARGET=${X86_DEPLOY}
 
             # Debug Build
             mkdir -p "build_debug"
@@ -190,9 +172,6 @@ pushd "$top/openal-soft"
                 cmake --build . --config Release
                 cmake --install . --config Release
             popd
-
-            # ARM64 Deploy Target
-            export MACOSX_DEPLOYMENT_TARGET=${ARM64_DEPLOY}
 
             # Debug Build
             mkdir -p "build_debug_arm64"
@@ -289,18 +268,9 @@ pushd "$top/openal-soft"
         ;;
 
         linux*)
-            # Default target per --address-size
-            opts="${TARGET_OPTS:--m$AUTOBUILD_ADDRSIZE}"
-
-            # Setup build flags
-            DEBUG_COMMON_FLAGS="$opts -Og -g -fPIC -DPIC"
-            RELEASE_COMMON_FLAGS="$opts -O3 -g -fPIC -DPIC -fstack-protector-strong -D_FORTIFY_SOURCE=2"
-            DEBUG_CFLAGS="$DEBUG_COMMON_FLAGS"
-            RELEASE_CFLAGS="$RELEASE_COMMON_FLAGS"
-            DEBUG_CXXFLAGS="$DEBUG_COMMON_FLAGS -std=c++17"
-            RELEASE_CXXFLAGS="$RELEASE_COMMON_FLAGS -std=c++17"
-            DEBUG_CPPFLAGS="-DPIC"
-            RELEASE_CPPFLAGS="-DPIC"
+            # Default target per autobuild build --address-size
+            opts="${TARGET_OPTS:--m$AUTOBUILD_ADDRSIZE $LL_BUILD_RELEASE}"
+            plainopts="$(remove_cxxstd $opts)"
 
             # Handle any deliberate platform targeting
             if [ -z "${TARGET_CPPFLAGS:-}" ]; then
@@ -313,29 +283,16 @@ pushd "$top/openal-soft"
 
             # Create staging dirs
             mkdir -p "$stage/include/AL"
-            mkdir -p "${stage}/lib/debug"
             mkdir -p "${stage}/lib/release"
 
-            # Debug Build
-            mkdir -p "build_debug"
-            pushd "build_debug"
-                cmake -E env CFLAGS="$DEBUG_CFLAGS" CXXFLAGS="$DEBUG_CXXFLAGS" \
-                cmake .. -DCMAKE_BUILD_TYPE="Debug" \
-                    -DALSOFT_UTILS=OFF -DALSOFT_NO_CONFIG_UTIL=ON -DALSOFT_EXAMPLES=OFF -DALSOFT_TESTS=OFF \
-                    -DCMAKE_INSTALL_PREFIX="$stage"
-
-                cmake --build . -j$AUTOBUILD_CPU_COUNT --config Debug --clean-first
-
-                cp -a libopenal.so* "$stage/lib/debug/"
-            popd
-
             # Release Build
-            mkdir -p "build_release"
-            pushd "build_release"
-                cmake -E env CFLAGS="$RELEASE_CFLAGS" CXXFLAGS="$RELEASE_CXXFLAGS" \
-                cmake .. -DCMAKE_BUILD_TYPE="Release" \
-                    -DALSOFT_UTILS=OFF -DALSOFT_NO_CONFIG_UTIL=ON -DALSOFT_EXAMPLES=OFF -DALSOFT_TESTS=OFF \
-                    -DCMAKE_INSTALL_PREFIX="$stage"
+            mkdir -p "build"
+            pushd "build"
+                cmake .. -G Ninja -DCMAKE_BUILD_TYPE="Release" \
+                    -DALSOFT_UTILS=OFF -DALSOFT_NO_CONFIG_UTIL=ON -DALSOFT_EXAMPLES=OFF \
+                    -DCMAKE_INSTALL_PREFIX="$stage" \
+                    -DCMAKE_C_FLAGS="$plainopts" \
+                    -DCMAKE_CXX_FLAGS="$opts"
 
                 cmake --build . -j$AUTOBUILD_CPU_COUNT --config Release --clean-first
 
@@ -344,7 +301,7 @@ pushd "$top/openal-soft"
             cp include/AL/*.h $stage/include/AL/
 
             # Must be done after the build.  version.h is created as part of the build.
-            version="$(sed -n -E 's/#define ALSOFT_VERSION "([^"]+)"/\1/p' "build_release/version.h" | tr -d '\r' )"
+            version="$(sed -n -E 's/#define ALSOFT_VERSION "([^"]+)"/\1/p' "build/version.h" | tr -d '\r' )"
             echo "${version}" > "${stage}/VERSION.txt"
         ;;
     esac
@@ -356,40 +313,23 @@ pushd "$top/freealut"
         windows*)
             load_vsvars
 
-            if [ "$AUTOBUILD_ADDRSIZE" = 32 ]
-            then
-                archflags=""
-            else
-                archflags=""
-            fi
-
             # Create staging dirs
             mkdir -p "$stage/include/AL"
             mkdir -p "${stage}/lib/debug"
             mkdir -p "${stage}/lib/release"
 
-            # Debug Build
-            mkdir -p "build_debug"
-            pushd "build_debug"
-
-                cmake -E env CFLAGS="$archflags /Zi" CXXFLAGS="$archflags /Zi" LDFLAGS="/DEBUG:FULL" \
-                cmake .. -G "$AUTOBUILD_WIN_CMAKE_GEN" -A "$AUTOBUILD_WIN_VSPLATFORM" -DCMAKE_BUILD_TYPE="Debug" \
-                    -DOPENAL_LIB_DIR="$(cygpath -m "$stage/lib/debug")" -DOPENAL_INCLUDE_DIR="$(cygpath -m "$stage/include")" \
-                    -DBUILD_STATIC=OFF -DCMAKE_INSTALL_PREFIX="$(cygpath -m "$stage")"
-
-                cmake --build . --config Debug --clean-first
-
-                cp -a Debug/alut.{lib,dll,exp,pdb} "$stage/lib/debug/"
-            popd
+            opts="$LL_BUILD_RELEASE"
+            plainopts="$(remove_cxxstd $opts)"
 
             # Release Build
-            mkdir -p "build_release"
-            pushd "build_release"
-
-                cmake -E env CFLAGS="$archflags /O2 /Ob3 /GL /Gy /Zi" CXXFLAGS="$archflags /O2 /Ob3 /GL /Gy /Zi /std:c++17 /permissive-" LDFLAGS="/LTCG /OPT:REF /OPT:ICF /DEBUG:FULL" \
-                cmake .. -G "$AUTOBUILD_WIN_CMAKE_GEN" -A "$AUTOBUILD_WIN_VSPLATFORM" -DCMAKE_BUILD_TYPE="Release" \
+            mkdir -p "build"
+            pushd "build"
+                cmake .. -G "Ninja Multi-Config" -DCMAKE_BUILD_TYPE="Release" \
                     -DOPENAL_LIB_DIR="$(cygpath -m "$stage/lib/release")" -DOPENAL_INCLUDE_DIR="$(cygpath -m "$stage/include")" \
-                    -DBUILD_STATIC=OFF -DCMAKE_INSTALL_PREFIX="$(cygpath -m "$stage")"
+                    -DBUILD_STATIC=OFF -DCMAKE_INSTALL_PREFIX="$(cygpath -m "$stage")" \
+                    -DCMAKE_C_FLAGS="$plainopts" \
+                    -DCMAKE_CXX_FLAGS="$opts" \
+                    -DCMAKE_SHARED_LINKER_FLAGS="/DEBUG:FULL"
 
                 cmake --build . --config Release --clean-first
 
@@ -404,12 +344,11 @@ pushd "$top/freealut"
             export SDKROOT=$(xcodebuild -version -sdk ${SDKNAME} Path)
 
             # Deploy Targets
-            X86_DEPLOY=10.15
-            ARM64_DEPLOY=11.0
+            export MACOSX_DEPLOYMENT_TARGET="$LL_BUILD_DARWIN_DEPLOY_TARGET"
 
             # Setup build flags
-            ARCH_FLAGS_X86="-arch x86_64 -mmacosx-version-min=${X86_DEPLOY} -isysroot ${SDKROOT} -msse4.2"
-            ARCH_FLAGS_ARM64="-arch arm64 -mmacosx-version-min=${ARM64_DEPLOY} -isysroot ${SDKROOT}"
+            ARCH_FLAGS_X86="-arch x86_64 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET} -isysroot ${SDKROOT} -msse4.2"
+            ARCH_FLAGS_ARM64="-arch arm64 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET} -isysroot ${SDKROOT}"
             DEBUG_COMMON_FLAGS="-O0 -g -fPIC -DPIC"
             RELEASE_COMMON_FLAGS="-O3 -g -fPIC -DPIC -fstack-protector-strong"
             DEBUG_CFLAGS="$DEBUG_COMMON_FLAGS"
@@ -420,9 +359,6 @@ pushd "$top/freealut"
             RELEASE_CPPFLAGS="-DPIC"
             DEBUG_LDFLAGS="-Wl,-headerpad_max_install_names"
             RELEASE_LDFLAGS="-Wl,-headerpad_max_install_names"
-
-            # x86 Deploy Target
-            export MACOSX_DEPLOYMENT_TARGET=${X86_DEPLOY}
 
             # Debug Build
             mkdir -p "build_debug_x86"
@@ -489,9 +425,6 @@ pushd "$top/freealut"
                 cmake --build . --config Release
                 cmake --install . --config Release
             popd
-
-            # ARM64 Deploy Target
-            export MACOSX_DEPLOYMENT_TARGET=${ARM64_DEPLOY}
 
             # Debug Build
             mkdir -p "build_debug_arm64"
@@ -598,35 +531,9 @@ pushd "$top/freealut"
             fi
         ;;
         linux*)
-            # Linux build environment at Linden comes pre-polluted with stuff that can
-            # seriously damage 3rd-party builds.  Environmental garbage you can expect
-            # includes:
-            #
-            #    DISTCC_POTENTIAL_HOSTS     arch           root        CXXFLAGS
-            #    DISTCC_LOCATION            top            branch      CC
-            #    DISTCC_HOSTS               build_name     suffix      CXX
-            #    LSDISTCC_ARGS              repo           prefix      CFLAGS
-            #    cxx_version                AUTOBUILD      SIGN        CPPFLAGS
-            #
-            # So, clear out bits that shouldn't affect our configure-directed build
-            # but which do nonetheless.
-            #
-            # unset DISTCC_HOSTS CC CXX CFLAGS CPPFLAGS CXXFLAGS
-
-            # Default target per --address-size
-            opts="${TARGET_OPTS:--m$AUTOBUILD_ADDRSIZE}"
-
-            # Setup build flags
-            DEBUG_COMMON_FLAGS="$opts -Og -g -fPIC -DPIC"
-            RELEASE_COMMON_FLAGS="$opts -O3 -g -fPIC -DPIC -fstack-protector-strong -D_FORTIFY_SOURCE=2"
-            DEBUG_CFLAGS="$DEBUG_COMMON_FLAGS"
-            RELEASE_CFLAGS="$RELEASE_COMMON_FLAGS"
-            DEBUG_CXXFLAGS="$DEBUG_COMMON_FLAGS -std=c++17"
-            RELEASE_CXXFLAGS="$RELEASE_COMMON_FLAGS -std=c++17"
-            DEBUG_CPPFLAGS="-DPIC"
-            RELEASE_CPPFLAGS="-DPIC"
-
-            JOBS=`cat /proc/cpuinfo | grep processor | wc -l`
+            # Default target per autobuild build --address-size
+            opts="${TARGET_OPTS:--m$AUTOBUILD_ADDRSIZE $LL_BUILD_RELEASE}"
+            plainopts="$(remove_cxxstd $opts)"
 
             # Handle any deliberate platform targeting
             if [ -z "${TARGET_CPPFLAGS:-}" ]; then
@@ -642,28 +549,16 @@ pushd "$top/freealut"
             mkdir -p "${stage}/lib/debug"
             mkdir -p "${stage}/lib/release"
 
-            # Debug Build
-            mkdir -p "build_debug"
-            pushd "build_debug"
-                cmake -E env CFLAGS="$DEBUG_CFLAGS" CXXFLAGS="$DEBUG_CXXFLAGS" \
-                cmake .. -DCMAKE_BUILD_TYPE="Debug" \
-                    -DOPENAL_LIB_DIR="$stage/lib/debug" -DOPENAL_INCLUDE_DIR="$stage/include" \
-                    -DBUILD_STATIC=OFF -DCMAKE_INSTALL_PREFIX="$stage"
-
-                cmake --build . -j$JOBS --config Debug --clean-first
-
-                cp -a libalut.so* "$stage/lib/debug/"
-            popd
-
             # Release Build
-            mkdir -p "build_release"
-            pushd "build_release"
-                cmake -E env CFLAGS="$RELEASE_CFLAGS" CXXFLAGS="$RELEASE_CXXFLAGS" \
-                cmake .. -DCMAKE_BUILD_TYPE="Release" \
+            mkdir -p "build"
+            pushd "build"
+                cmake .. -G Ninja -DCMAKE_BUILD_TYPE="Release" \
                     -DOPENAL_LIB_DIR="$stage/lib/release" -DOPENAL_INCLUDE_DIR="$stage/include" \
-                    -DBUILD_STATIC=OFF -DCMAKE_INSTALL_PREFIX="$stage"
+                    -DBUILD_STATIC=OFF -DCMAKE_INSTALL_PREFIX="$stage" \
+                    -DCMAKE_C_FLAGS="$plainopts" \
+                    -DCMAKE_CXX_FLAGS="$opts"
 
-                cmake --build . -j$JOBS --config Release --clean-first
+                cmake --build . -j$AUTOBUILD_CPU_COUNT --config Release --clean-first
                 
                 cp -a libalut.so* "$stage/lib/release/"
             popd


### PR DESCRIPTION
Cleans up windows and linux build targets to consistently use build-variables

Use Ninja where possible to accelerate build

Enables pipewire backend on linux